### PR TITLE
adding support for stage in set_model_version_tag

### DIFF
--- a/mlflow/tracking/_model_registry/client.py
+++ b/mlflow/tracking/_model_registry/client.py
@@ -306,7 +306,7 @@ class ModelRegistryClient:
         """
         return self.store.get_model_version_stages(name, version)
 
-    def set_model_version_tag(self, name, version, key, value):
+    def set_model_version_tag(self, name, version=None, key=None, value=None, stage=None):
         """
         Set a tag for the model version.
 
@@ -316,6 +316,9 @@ class ModelRegistryClient:
         :param value: Tag value to log.
         :return: None
         """
+        if not version and stage:
+            model_versions = self.get_latest_versions(name, [stage])
+            version = model_versions[0].version if model_versions else None
         self.store.set_model_version_tag(name, version, ModelVersionTag(key, str(value)))
 
     def delete_model_version_tag(self, name, version, key):

--- a/mlflow/tracking/_model_registry/client.py
+++ b/mlflow/tracking/_model_registry/client.py
@@ -306,7 +306,7 @@ class ModelRegistryClient:
         """
         return self.store.get_model_version_stages(name, version)
 
-    def set_model_version_tag(self, name, version=None, key=None, value=None):
+    def set_model_version_tag(self, name, version, key, value):
         """
         Set a tag for the model version.
 

--- a/mlflow/tracking/_model_registry/client.py
+++ b/mlflow/tracking/_model_registry/client.py
@@ -306,7 +306,7 @@ class ModelRegistryClient:
         """
         return self.store.get_model_version_stages(name, version)
 
-    def set_model_version_tag(self, name, version=None, key=None, value=None, stage=None):
+    def set_model_version_tag(self, name, version=None, key=None, value=None):
         """
         Set a tag for the model version.
 
@@ -316,9 +316,6 @@ class ModelRegistryClient:
         :param value: Tag value to log.
         :return: None
         """
-        if not version and stage:
-            model_versions = self.get_latest_versions(name, [stage])
-            version = model_versions[0].version if model_versions else None
         self.store.set_model_version_tag(name, version, ModelVersionTag(key, str(value)))
 
     def delete_model_version_tag(self, name, version, key):

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -2681,7 +2681,9 @@ class MlflowClient:
         """
         return ALL_STAGES
 
-    def set_model_version_tag(self, name: str, version: str, key: str, value: Any) -> None:
+    def set_model_version_tag(
+        self, name: str, version: str = None, key: str = None, value: Any = None, stage: str = None
+    ) -> None:
         """
         Set a tag for the model version.
 
@@ -2738,7 +2740,7 @@ class MlflowClient:
             Version: 1
             Tags: {'t': '1'}
         """
-        self._get_registry_client().set_model_version_tag(name, version, key, value)
+        self._get_registry_client().set_model_version_tag(name, version, key, value, stage)
 
     def delete_model_version_tag(self, name: str, version: str, key: str) -> None:
         """

--- a/mlflow/utils/validation.py
+++ b/mlflow/utils/validation.py
@@ -388,6 +388,9 @@ def _validate_db_type_string(db_type):
         raise MlflowException(error_msg, INVALID_PARAMETER_VALUE)
 
 
-def _validate_version_or_stage(version, stage):
+def _validate_model_version_or_stage_exists(version, stage):
+    if version and stage:
+        raise MlflowException("Only version or stage should be set")
+
     if not (version or stage):
         raise MlflowException("version or stage should be set")

--- a/mlflow/utils/validation.py
+++ b/mlflow/utils/validation.py
@@ -386,3 +386,8 @@ def _validate_db_type_string(db_type):
     if db_type not in DATABASE_ENGINES:
         error_msg = "Invalid database engine: '%s'. '%s'" % (db_type, _UNSUPPORTED_DB_TYPE_MSG)
         raise MlflowException(error_msg, INVALID_PARAMETER_VALUE)
+
+
+def _validate_version_or_stage(version, stage):
+    if not (version or stage):
+        raise MlflowException("version or stage should be set")

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -592,3 +592,31 @@ def test_client_can_be_serialized_with_pickle(tmpdir):
     client.create_experiment("test_experiment")
     client.create_registered_model("test_model")
     pickle.dumps(client)
+
+
+def test_set_model_version_tag(mock_registry_store):
+
+    mock_get_latest_versions = mock.Mock()
+    mock_get_latest_versions.return_value = [
+        ModelVersion(
+            "test_model_name",
+            "1",
+            0,
+        )
+    ]
+
+    mock_registry_store.get_latest_versions = mock_get_latest_versions
+
+    MlflowClient().set_model_version_tag("model_name", "1", "tag1", "foobar")
+    mock_registry_store.set_model_version_tag.assert_called_once_with(
+        "model_name", "1", ModelVersionTag(key="tag1", value="foobar")
+    )
+
+    mock_registry_store.reset_mock()
+
+    MlflowClient().set_model_version_tag(
+        "model_name", version=None, key="tag1", value="foobar", stage="Staging"
+    )
+    mock_registry_store.set_model_version_tag.assert_called_once_with(
+        "model_name", "1", ModelVersionTag(key="tag1", value="foobar")
+    )


### PR DESCRIPTION
Signed-off-by: Subramaniam Shanmugam <subras@adobe.com>

implements #5327

## What changes are proposed in this pull request?

1. support stage in set_model_version_tag
2. Test cases & validations to be added after finalizing the approach

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [ ] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
4. Click `Details` on the right to open the job page of CircleCI.
5. Click the `Artifacts` tab.
6. Click `docs/build/html/index.html`.
7. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/pipelines`: Pipelines, Pipeline APIs, Pipeline configs, Pipeline Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
